### PR TITLE
update custom view docs & add step extension api reference

### DIFF
--- a/content/docs/add-custom-view.md
+++ b/content/docs/add-custom-view.md
@@ -179,23 +179,23 @@ properties we've just defined above:
 - `module` here corresponds to the `exposes` object, or the components 
   you're exposing.
 - `scope` MUST match the `name` of your application that we defined earlier
+- `constraints` defines when the extension will be shown. In this
+   example, the extension will be shown when configuring the
+   `twitter-search-source` step. It will appear as a new "Fun Component"
+   tab when you click on it in the Visualization.
 
 It is important that the `url` points to where you have deployed the extension
 implemented in the previous step.
-
-The `constraints` will define when this extension will be shown. In this 
-example, the extension will be shown when configuring the 
-`twitter-search-source` step. It will appear as a new "Fun Component" 
-tab when you click on `twitter-search-source` in Kaoto.
 
 ## Putting it All Together
 
 You should now have an application that has Webpack Module Federation 
 enabled, with a defined component that you want to stream to Kaoto. Start 
-the Kaoto backend as usual, ensuring that its
+the Kaoto backend as usual, ensuring that it is pointing to the correct View 
+Definition catalog.
 
-Stay turned for details on what you can do with your Step Extension, as 
-we've just released a brand-new API for interacting with Kaoto's state. 
+Check out our documentation for the [Step Extension API](/step-extension-api),
+as we've just released a brand-new API for interacting with Kaoto's state. 
 
 
 

--- a/content/docs/add-custom-view.md
+++ b/content/docs/add-custom-view.md
@@ -10,7 +10,6 @@ categories:
 - Extension
 - Frontend
 image: "/images/step-extension.png"
-
 ---
 
 Kaoto's frontend is extendable, allowing you to create custom views that you
@@ -194,7 +193,7 @@ enabled, with a defined component that you want to stream to Kaoto. Start
 the Kaoto backend as usual, ensuring that it is pointing to the correct View 
 Definition catalog.
 
-Check out our documentation for the [Step Extension API](/step-extension-api),
+Check out our documentation for the [Step Extension API](/docs/step-extension-api),
 as we've just released a brand-new API for interacting with Kaoto's state. 
 
 

--- a/content/docs/step-extension-api.md
+++ b/content/docs/step-extension-api.md
@@ -2,7 +2,7 @@
 title: "Step Extension API"
 description: "Documentation for working with the Step Extension API."
 draft: false
-date: "2022-06-14"
+date: "2022-06-21"
 tags:
 - Custom View
 categories:

--- a/content/docs/step-extension-api.md
+++ b/content/docs/step-extension-api.md
@@ -12,142 +12,61 @@ categories:
 
 ---
 
-We previously showed you how you can [extended Kaoto with custom views](/add-custom-view) called **Step Extensions**.
-
-![Example of a Step Extension](/images/step-extension.png)
+We previously showed you how you can [extend Kaoto with custom views](/docs/add-custom-view) called **Step Extensions**.
 
 Once you have a Step Extension, you will likely want to be able to interact 
 with Kaoto's state, maybe sharing some of your application's state with 
 Kaoto as well.
 
-## Custom Views
+## Concepts & Usage
 
-Each Step Extension is, in essence, a web application that uses Webpack 4.x
-or later. This can even be in the form of built static files. In fact, this is
-how we are able to host our [example](https://step-extension.netlify.app/) on Netlify. You can use this [example extension](https://github.com/KaotoIO/step-extension) as a guide.
+For the purposes of this tutorial we will assume you have a very plain 
+extension, just a React application that uses Webpack 5.x, and it has a 
+basic button component like this:
 
-Or maybe you already have an external application that you'd like to have
-embedded within Kaoto. All you would have to do is point to it from your View
-Definition catalog. We'll take a look at how you can do that in just a moment.
+```jsx
+const buttonStyling = {
+  backgroundColor: 'BlueViolet',
+  color: 'white',
+  borderRadius: '25px',
+  padding: '20px'
+};
 
-## Under the Hood
+const Example = () => {
+  return (
+    <button style={buttonStyling}>Click to Notify Kaoto</button>
+  )
+};
 
-Because we are using Webpack 5's [module federation](https://webpack.js.org/concepts/module-federation/) under the hood, it means that your
-application would need to use Webpack 4.x or later to take advantage of step
-extensions. Webpack can be used in tandem with other tools like Rollup, and
-you can even use it just for module federation if you choose to.
+export default Example;
+```
 
-If you're not familiar with the concept of module federation, you don't need
-to be. The important thing to know is that it gives you the flexibility to
-deploy your application separately, and Kaoto wouldn't even need to be
-restarted. Dependency alignment is a thing of the past with module
-federation, as you can even specify whether you want to share a
-particular version of a framework like React, or if you want to use your own.
+Keeping in mind that Kaoto is simply an application that is importing your 
+`Example` component, if the Step Extension API provides a `notifyKaoto` 
+method, we could reference it like this from within our component:
 
-## Enabling Module Federation in Your App
+```jsx
+const Example = (props) => {
+  const handleClick = () => {
+    if (props.notifyKaoto) {
+      props.notifyKaoto('Message from my remote Step Extension!', 'this is the description of the notification', 'success');
+    }
+  };
 
-One of the biggest benefits of using module federation is that it works just
-like any other `import`. This means **you don't have to make any alterations
-to an existing code base**. It's simply a matter of configuring it.
-
-When you enable module federation, your `webpack.config.js` file will look 
-something like this:
-
-```js
-const HtmlWebPackPlugin = require("html-webpack-plugin");
-const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
-const deps = require("./package.json").dependencies;
-
-module.exports = {
-  devServer: {
-    port: 3000,
-    historyApiFallback: true,
-  },
-  output: {
-    publicPath: "http://localhost:3000/",
-  },
-  resolve: {
-    extensions: [".tsx", ".ts", ".jsx", ".js", ".json"],
-  },
-  plugins: [
-    new ModuleFederationPlugin({
-      name: "funapp",
-      filename: "remoteEntry.js",
-      exposes: {
-        "./FunComponent": "./src/FunComponent",
-      },
-      shared: {
-        ...deps,
-        react: {
-          singleton: true,
-          requiredVersion: deps.react,
-        },
-        "react-dom": {
-          singleton: true,
-          requiredVersion: deps["react-dom"],
-        }, },
-    }),
-    new HtmlWebPackPlugin({
-      template: "./src/index.html",
-    }),
-  ],
+  return (
+    <button style={buttonStyling} onClick={handleClick}>Click to Notify Kaoto</button>
+  )
 };
 ```
 
-Some important things to note is the `ModuleFederationPlugin`, which comes 
-built into Webpack. In it, you have a few properties that are relevant:
+With Kaoto running and our View Definition catalog pointing to this app (and 
+component), we can now view this Step Extension in whichever step it's 
+configured to be displayed for. Clicking on the button from the remote 
+application should trigger a notification in Kaoto.
 
-- `name`: The name of your application. This cannot conflict with another Step Extension `name`.
-- `filename`: This is the name of your remote entry file, which is usually 
-  `remoteEntry.js`.
-- `exposes`: The files this application will expose to Kaoto. Typically, 
-  this will be a single component. In this example, we are sharing a component 
-  called `FunComponent`.
-- `shared`: Any libraries you want to share with Kaoto.
-
-There are other options we won't go into, but these are the basics.
-
-## Add View Definition to repository
-
-To make Kaoto aware of your Step Extension, you need to point to its
-`remoteEntry.js` file (generated by Webpack), from your View Definition 
-Catalog. You can use one of the [default View Definition catalogs](https://github.com/KaotoIO/kaoto-viewdefinition-catalog).
-
-This is what that would look like:
-
-```yaml {linenos=inline,hl_lines=[4,5,6],linenostart=1}
-name: Fun Component
-id: detail-step
-type: step
-url: http://localhost:8000
-module: './FunComponent'
-scope: 'funapp'
-constraints: 
-   -
-      mandatory: true
-      operation: CONTAINS_STEP_NAME
-      parameter: twitter-search-source      
-```
-
-Most of these properties are simply mapping to the `ModuleFederationPlugin` 
-properties we've just defined above:
-
-- `name` is what will appear as the label of the new tab of the component
-- `url` is where your application is running
-- `module` here corresponds to the `exposes` object, or the components 
-  you're exposing.
-- `scope` MUST match the `name` of your application that we defined earlier
-
-It is important that the `url` points to where you have deployed the extension
-implemented in the previous step.
-
-The `constraints` will define when this extension will be shown. In this 
-example, the extension will be shown when configuring the 
-`twitter-search-source` step. It will appear as a new "Fun Component" 
-tab when you click on `twitter-search-source` in Kaoto.
-
-Stay turned for details on what you can do with your Step Extension, as 
-we've just released a brand-new API for interacting with Kaoto's state. 
-
+Now that you understand how Step Extensions work, you can check out 
+the other methods available [here](https://github.com/KaotoIO/kaoto-ui/blob/main/src/api/stepExtensionApi.ts). If we don't 
+support something you'd want to see, please let us know by [creating an 
+issue](https://github.com/KaotoIO/kaoto-ui/issues/new/choose).
 
 

--- a/content/docs/step-extension-api.md
+++ b/content/docs/step-extension-api.md
@@ -1,68 +1,26 @@
 ---
-title: "Add a Custom View"
-description: "How to add a custom view for specific steps."
+title: "Step Extension API"
+description: "Documentation for working with the Step Extension API."
 draft: false
-date: "2022-01-10"
+date: "2022-06-14"
 tags:
 - Custom View
 categories:
 - Development
 - Extension
 - Frontend
-image: "/images/step-extension.png"
 
 ---
 
-Kaoto's frontend is extendable, allowing you to create custom views that you
-can configure to show for specific steps. We call these custom views **Step
-Extensions**.
+We previously showed you how you can [extended Kaoto with custom views](/add-custom-view) called **Step Extensions**.
 
 ![Example of a Step Extension](/images/step-extension.png)
 
-You can use the Step Extension API to interact with Kaoto's internal state,
-whether that be to control deployments remotely, or to do some kind of data
-transformation with the output of a particular step.
+Once you have a Step Extension, you will likely want to be able to interact 
+with Kaoto's state, maybe sharing some of your application's state with 
+Kaoto as well.
 
-There are two parts to adding a step extension:
-
-1. The Step Extension itself, which is simply your remote application that 
-   uses Webpack version 4.x or later.
-2. The View Definition catalog. The Kaoto API uses this under the hood to 
-   determine what views to send to the frontend. You will have to modify 
-   [the one being used by default](https://github.com/KaotoIO/kaoto-viewdefinition-catalog), or provide your own, which 
-   should be specified [here](https://github.com/KaotoIO/kaoto-backend/blob/main/api/src/main/resources/application.yaml#L8).
-
-For the View Definition catalog, if you add a custom one, you don't have to 
-specify it as a JAR file, it can be a simple GitHub repo instead, which 
-would be referenced this way:
-
-```yaml {linenos=inline,hl_lines=[54-57],linenostart=39}
-repository:
-  step:
-    jar:
-      - "https://repo1.maven.org/maven2/org/apache/camel/kamelets/camel-kamelets/0.6.0/camel-kamelets-0.6.0.jar"
-      - "https://github.com/KaotoIO/camel-component-metadata/archive/refs/heads/main.zip"
-    git:
-      -
-        url: "https://github.com/KaotoIO/camel-component-metadata.git"
-        tag: "main"
-      -
-        url: "git@github.com:kahboom/custom-step-catalog.git"
-        tag: "main"
-  viewdefinition:
-    jar:
-      - "https://github.com/KaotoIO/kaoto-viewdefinition-catalog/archive/refs/heads/main.zip"
-    git:
-      -
-        url: "https://github.com/KaotoIO/kaoto-viewdefinition-catalog.git"
-        tag: "main"
-      -
-        url: "git@github.com:kahboom/custom-viewdefinition-catalog.git"
-        tag: "main"
-```
-
-
-## Step Extensions
+## Custom Views
 
 Each Step Extension is, in essence, a web application that uses Webpack 4.x
 or later. This can even be in the form of built static files. In fact, this is
@@ -187,12 +145,6 @@ The `constraints` will define when this extension will be shown. In this
 example, the extension will be shown when configuring the 
 `twitter-search-source` step. It will appear as a new "Fun Component" 
 tab when you click on `twitter-search-source` in Kaoto.
-
-## Putting it All Together
-
-You should now have an application that has Webpack Module Federation 
-enabled, with a defined component that you want to stream to Kaoto. Start 
-the Kaoto backend as usual, ensuring that its
 
 Stay turned for details on what you can do with your Step Extension, as 
 we've just released a brand-new API for interacting with Kaoto's state. 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -138,5 +138,33 @@ td pre {
     border-radius: 15px;
 }
 
+.content ol {
+    counter-reset: li;
+    font-size: 14px;
+    line-height: 18px;
+    list-style-type: none;
+    padding-left: 10px;
+}
+
+.content ol li {
+    padding: 5px 0 5px 30px;
+    position: relative;
+}
+
+.content ol li:before {
+    background-color: #383a3d;
+    border: 1px solid #383a3d;
+    border-radius: 50%;
+    color: white;
+    content: counter(li);
+    counter-increment: li;
+    height: 20px;
+    left: 0;
+    position: absolute;
+    text-align: center;
+    top: 4px;
+    width: 20px;
+}
+
 
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -118,7 +118,7 @@ pre {
     color: #212529;
     display: block;
     font-size: 87.5%;
-    padding: 3em 2em;
+    padding: 2em;
 }
 
 td pre {


### PR DESCRIPTION
- made some minor changes to the custom view docs (see diff)
- styling improvements (added a little circle to numbered lists)
- added a step extension API page to the docs, which points to the file itself

In the near future we will use something like the Kaoto API has for publishing the docs from the API itself.

![Captura de Pantalla 2022-06-21 a la(s) 1 00 03 p  m](https://user-images.githubusercontent.com/3844502/174794223-c9e07633-d3c9-4821-bf09-03bad334fb7a.png)

