### PR TITLE
fix Use official VS Code naming

### DIFF
--- a/themes/kross-hugo/layouts/index.html
+++ b/themes/kross-hugo/layouts/index.html
@@ -11,8 +11,8 @@
             <a href="/quickstart" title="Kaoto Quickstart" class="btn btn-primary btn-cta border mt-4 pt-1 pb-1 mr-2">
               🚀&nbsp;&nbsp;Get Started
             </a>
-            <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto" title="VSCode Extension" class="btn btn-primary btn-cta border mt-4 pt-1 pb-1 mr-2 vscode" target="_blank">
-             &nbsp;&nbsp;VSCode Extension
+            <a href="https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto" title="VS Code Extension" class="btn btn-primary btn-cta border mt-4 pt-1 pb-1 mr-2 vscode" target="_blank">
+             &nbsp;&nbsp;VS Code Extension
             </a>
           </div>
         </div>


### PR DESCRIPTION
official naming are "Visual Studio Code" and "VS Code", see notations used in https://code.visualstudio.com/docs

Signed-off-by: Aurélien Pupier <apupier@redhat.com>