### PR TITLE
fix(docs): Fix broken link to Kaoto API

### DIFF
--- a/content/docs/step-extension-api.md
+++ b/content/docs/step-extension-api.md
@@ -14,17 +14,17 @@ categories:
 
 You can [extend Kaoto with custom views](/docs/add-custom-view) called **Step Extensions**.
 
-Once you have a Step Extension, you will likely want to be able to interact 
-with Kaoto's state, maybe sharing some of your application's state with 
+Once you have a Step Extension, you will likely want to be able to interact
+with Kaoto's state, maybe sharing some of your application's state with
 Kaoto as well.
 
-For example, you may want to show a form to configure properties on a step and 
+For example, you may want to show a form to configure properties on a step and
 then notify Kaoto of the changes so the workflow gets updated.
 
 ## Concepts & Usage
 
-For the purposes of this tutorial we will assume you have a very plain 
-extension [as described here](/docs/add-custom-view). For example, 
+For the purposes of this tutorial we will assume you have a very plain
+extension [as described here](/docs/add-custom-view). For example,
 just a React application that uses Webpack 5.x, and has a basic button component like this:
 
 ```jsx
@@ -44,11 +44,11 @@ const Example = () => {
 export default Example;
 ```
 
-Keeping in mind that Kaoto is simply an application that is importing your 
+Keeping in mind that Kaoto is simply an application that is importing your
 `Example` component. You can use the **Step Extension API** provided by Kaoto to
 interact with the main application, sharing data back and forth.
 
-For example, the **Step Extension API** provides a `notifyKaoto` method, which we 
+For example, the **Step Extension API** provides a `notifyKaoto` method, which we
 could reference like this from within our component:
 
 ```jsx
@@ -66,17 +66,15 @@ const Example = (props) => {
 ```
 
 
-If you haven't already done so, you can 
+If you haven't already done so, you can
 [configure Kaoto to use your extension](/docs/add-custom-view).
 
-With Kaoto configured with our extension, you can now use this Step Extension in the step it's configured to be displayed for. 
+With Kaoto configured with our extension, you can now use this Step Extension in the step it's configured to be displayed for.
 Clicking on the button from the remote application should trigger a notification in Kaoto.
 
-Now that you understand how Step Extensions work, you can check out 
-[the other methods available on the Step Extension API](https://github.com/KaotoIO/kaoto-ui/blob/main/src/components/StepExtensionApi.ts). 
+Now that you understand how Step Extensions work, you can check out
+[the other methods available on the Step Extension API](https://github.com/KaotoIO/kaoto-ui/blob/main/src/types/index.ts#L85-L107).
 
-If Kaoto doesn't support something you need, you can either 
-[contribute with the implementation](https://github.com/KaotoIO/kaoto-ui/blob/main/CONTRIBUTING.md#implementing-bug-fixes-or-features) 
+If Kaoto doesn't support something you need, you can either
+[contribute with the implementation](https://github.com/KaotoIO/kaoto-ui/blob/main/CONTRIBUTING.md#implementing-bug-fixes-or-features)
 or [contribute with an issue](https://github.com/KaotoIO/kaoto-ui/blob/main/CONTRIBUTING.md#submit-a-new-issue).
-
-


### PR DESCRIPTION
### Description
At the moment, the link for the Kaoto API definition it's broken, leading the user to a 404 in Github.

![image](https://user-images.githubusercontent.com/16512618/220211244-4cc3efb8-108b-481f-a7db-2074a7791cde.png)

### Changes
* Update the link URL to point to the updated file that holds the Kaoto API interface
