### PR TITLE
Fixed build and a few small text changes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -72,8 +72,8 @@ email = 'contact@kaoto.io'
 git = 'KaotoIO'
 twitter = 'KaotoIO'
 # meta description
-author = 'Kaoto Team'
-description = 'Kaoto is an extendable integration editor for low-code and no-code personas. Zero-ETL and much more with a visual multi-DSL flow editor.'
+# author = 'Kaoto Team'
+description = 'Kaoto is an Apache Camel integration editor for low-code and no-code personas. Zero-ETL and much more with a visual multi-DSL flow editor.'
 # google analytics
 google_analytics_id = 'G-BP1PVX7HSK' # Your ID
 # copyright

--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -1,13 +1,13 @@
 # banner
 banner:
   title : 'Kaoto'
-  body: 'Multi-DSL Flow Editor'
+  body: 'Camel Integration Editor'
   subText: 'Free & Open Source now and forever'
 
 # about
 about:
   enable : true
-  content : "Kaoto is a flow editor to create and deploy integrations in a visual, low-code way; with developer-friendly features like a code editor and deployments to the cloud. Kaoto augments user productivity via Zero-ETL: it accelerates new users and helps experienced developers."
+  content : "Kaoto is an editor to create and deploy integrations for Apache Camel in a visual, low-code way; with developer-friendly features like a code editor and deployments to the cloud. Kaoto augments user productivity via Zero-ETL: it accelerates new users and helps experienced developers."
 
   button:
     enable : true


### PR DESCRIPTION
This PR fixes the broken Hugo build caused by a breaking change with one of the later Hugo releases. This is done by removing the `author` parameter as suggesting in the workarounds for this problem. Hugo 0.120.4 extended has a fix incorporated but is not yet available for all distributions, which made me apply the workaround for the moment.

I also modified some texts to make it more clear that Kaoto is an editor for Apache Camel integrations.