### PR TITLE
Implement copy button to copy code content only

### DIFF
--- a/layouts/partials/hooks/body-end/custom.html
+++ b/layouts/partials/hooks/body-end/custom.html
@@ -17,5 +17,28 @@
 
     showItem(currentIndex);
     setInterval(nextItem, 10000); // Change item every 10 seconds
+
+    // Fix copy button: ensure only code content is copied, not the button text
+    document.addEventListener('click', function(e) {
+      const button = e.target.closest('.copy-button');
+      if (!button) return;
+      
+      // Find the code element in the same container
+      const codeElement = button.closest('.highlight, .chroma')?.querySelector('code') ||
+                          button.parentElement?.querySelector('code');
+      
+      if (codeElement) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        
+        const originalText = button.textContent;
+        navigator.clipboard.writeText(codeElement.textContent.trim()).then(function() {
+          button.textContent = 'Copied';
+          setTimeout(function() {
+            button.textContent = originalText;
+          }, 2000);
+        });
+      }
+    }, true);   
   });
 </script>


### PR DESCRIPTION
Added functionality to copy only code content when the copy button is clicked, preventing the button text from being copied.

The original problem was as follows, with the following Markdown definition:
```
example
```
The copy/paste action resulted in the following content in the clipboard when the user clicked:
<pre>
example
Copy
</pre>

The suggested change results in the following content in the clipboard (as the user expects):
<pre>
example
</pre>
