### PR TITLE
feat: playground tab

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -195,4 +195,3 @@ figure.image > img {
   cursor: zoom-in !important;
 }
 
-/* ...existing code... */

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -108,9 +108,24 @@ nav.hb-toc ul li a.pl-8, nav.hb-toc ul li a.pl-12, nav.hb-toc ul li a.pl-16 {
 }
 
 /* Align the header navbar with the content in bigger screens */
-@media (min-width: 1279px) {
+@media (min-width: 1600px) {
+  header.header > nav.navbar {
+    max-width: 1600px; /* Instead of 1280px */
+  }
+  
+  .mx-auto {
+    max-width: 1600px !important;
+  }
+}
+
+@media (max-width: 1600px) and (min-width: 1280px) {
   header.header > nav.navbar {
     max-width: 1280px;
+  }
+}
+
+@media (min-width: 1280px) {
+  header.header > nav.navbar {
     margin-left: auto;
     margin-right: auto;
   }

--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -12,6 +12,9 @@ main:
   - name: Documentation
     weight: 30
     url: docs/
+  - name: Playground
+    url: playground/
+    weight: 35
   - name: Roadmap
     url: roadmap/
     weight: 40

--- a/content/authors/_content.gotmpl
+++ b/content/authors/_content.gotmpl
@@ -1,5 +1,5 @@
-{{/* Get the author data from hugo.Data */}}
-{{ $authorData := hugo.Data.authors }}
+{{/* Get the author data from site.Data */}}
+{{ $authorData := site.Data.authors }}
 
 {{/* Iterate over each author key-value pair */}}
 {{ range $slug, $profile := $authorData }}

--- a/content/playground/_index.md
+++ b/content/playground/_index.md
@@ -1,0 +1,23 @@
+---
+title: 'Playground'
+date: 2026-05-21
+type: landing
+
+# SEO Meta Tags
+description: 'Try Kaoto online in our interactive playground'
+keywords:
+  - Kaoto Playground
+  - Try Kaoto Online
+  - Apache Camel Designer Demo
+
+sections:
+  - block: markdown
+    content:
+      title: ""
+      text: |-
+        {{< iframe-fullscreen src="https://red.ht/kaoto" title="Kaoto Playground" aspectRatio="16/9" mobileBreakpoint="700px" >}}
+    design:
+      spacing:
+        padding: ["1rem", 0, "1rem", 0]
+      css_class: "light"
+---

--- a/layouts/_partials/hbx/blocks/cta-image-paragraph/block.html
+++ b/layouts/_partials/hbx/blocks/cta-image-paragraph/block.html
@@ -2,7 +2,7 @@
 {{ $page := .wcPage }}
 {{ $block := .wcBlock }}
 
-<div class="mx-auto max-w-6xl px-6 py-12 lg:px-8">
+<div class="mx-auto max-w-96 px-6 py-12 lg:px-8">
   {{ with $block.content.items }}
     <div class="grid gap-12">
       {{ range $index, $item := . }}

--- a/layouts/_partials/hbx/blocks/features/block.html
+++ b/layouts/_partials/hbx/blocks/features/block.html
@@ -2,7 +2,7 @@
 {{ $page := .wcPage }}
 {{ $block := .wcBlock }}
 
-<div class="mx-auto max-w-6xl px-6 py-12 lg:px-8 text-center">
+<div class="mx-auto max-w-96 px-6 py-12 lg:px-8 text-center">
   {{ with $block.content.title }}
     <h2 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl text-center">
       {{ . | markdownify }}

--- a/layouts/_partials/hbx/blocks/hero2/block.html
+++ b/layouts/_partials/hbx/blocks/hero2/block.html
@@ -7,7 +7,7 @@
 {{ $block := .wcBlock }}
 <div class="relative isolate px-6 pt-1 lg:px-8">
 
-  <div class="mx-auto max-w-2xl py-1 sm:py-1 lg:py-2">
+  <div class="mx-auto max-w-screen-xl py-1 sm:py-1 lg:py-2">
 
     {{ if $block.content.announcement.text }}
     {{ $announcement := $block.content.announcement }}

--- a/layouts/_partials/hbx/blocks/markdown/block.html
+++ b/layouts/_partials/hbx/blocks/markdown/block.html
@@ -2,14 +2,14 @@
 {{ $page := .wcPage }}
 {{ $block := .wcBlock }}
 
-<div class="mx-auto max-w-5xl px-6 py-12 lg:px-8 text-center">
+<div class="mx-auto max-w-screen-xl px-6 py-12 lg:px-8 text-center">
   {{ with $block.content.title }}
     <h2 class="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl text-center">
       {{ . | markdownify }}
     </h2>
   {{ end }}
   {{ with $block.content.text }}
-    <div class="prose prose-lg dark:prose-invert mt-6 max-w-none text-center prose-img:mx-auto">
+    <div class="prose prose-lg dark:prose-invert mt-6 max-w-5xl mx-auto prose-img:mx-auto">
       {{ . | $page.RenderString | emojify }}
     </div>
   {{ end }}

--- a/layouts/_partials/hbx/blocks/slideshow/block.html
+++ b/layouts/_partials/hbx/blocks/slideshow/block.html
@@ -16,7 +16,7 @@
     <div class="mt-8 grid grid-cols-1 gap-8">
       {{ range $index, $item := $block.content.items }}
         <div class="item text-center{{ if eq $index 0 }} is-active{{ end }}" style="{{ if eq $index 0 }}display: block;{{ else }}display: none;{{ end }}">
-            <div class="max-w-screen-md mx-auto ">
+            <div class="max-w-screen-xl mx-auto ">
                 <svg class="h-16 mx-auto mb-3 text-gray-400 dark:text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 32 32">
                   <path d="M9.563 8.469l-0.813-1.25c-5.625 3.781-8.75 8.375-8.75 12.156 0 3.656 2.688 5.375 4.969 5.375 2.875 0 4.906-2.438 4.906-5 0-2.156-1.375-4-3.219-4.688-0.531-0.188-1.031-0.344-1.031-1.25 0-1.156 0.844-2.875 3.938-5.344zM21.969 8.469l-0.813-1.25c-5.563 3.781-8.75 8.375-8.75 12.156 0 3.656 2.75 5.375 5.031 5.375 2.906 0 4.969-2.438 4.969-5 0-2.156-1.406-4-3.313-4.688-0.531-0.188-1-0.344-1-1.25 0-1.156 0.875-2.875 3.875-5.344z"/>
                 </svg>

--- a/layouts/shortcodes/iframe-fullscreen.html
+++ b/layouts/shortcodes/iframe-fullscreen.html
@@ -1,0 +1,98 @@
+{{- $src := .Get "src" -}}
+{{- $title := .Get "title" | default "Embedded Content" -}}
+{{- $aspectRatio := .Get "aspectRatio" | default "16/9" -}}
+{{- $mobileBreakpoint := .Get "mobileBreakpoint" | default "700px" -}}
+{{- $uniqueId := printf "iframe%d" now.UnixNano -}}
+
+<style>
+.iframe-fullscreen-wrapper {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 150px);
+  min-height: {{ $mobileBreakpoint }};
+  aspect-ratio: {{ $aspectRatio }};
+}
+.iframe-fullscreen-wrapper:fullscreen {
+  aspect-ratio: auto;
+  max-height: none;
+}
+.iframe-fullscreen-wrapper:fullscreen iframe {
+  width: 100vw;
+  height: 100vh;
+}
+.iframe-fullscreen-wrapper:fullscreen button {
+  display: none;
+}
+.iframe-fullscreen-wrapper button {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.2s;
+}
+.iframe-fullscreen-wrapper button:hover {
+  background: rgba(0, 0, 0, 0.9);
+}
+.iframe-fullscreen-wrapper iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+.iframe-mobile-msg {
+  display: none;
+  text-align: center;
+  padding: 3rem 2rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+  margin: 2rem 0;
+}
+.iframe-mobile-msg h3 {
+  margin-top: 0;
+  color: #333;
+}
+.iframe-mobile-msg p {
+  color: #666;
+  line-height: 1.6;
+  margin: 1rem 0;
+}
+@media (max-width: {{ $mobileBreakpoint }}) {
+  .iframe-fullscreen-wrapper {
+    display: none;
+  }
+  .iframe-mobile-msg {
+    display: block;
+  }
+}
+</style>
+
+<script>
+function toggleFullscreen(wrapperId) {
+  var wrapper = document.getElementById(wrapperId);
+  if (document.fullscreenElement) {
+    document.exitFullscreen();
+  } else {
+    wrapper.requestFullscreen().catch(function(e) {
+      console.error('Error attempting to enable fullscreen:', e);
+    });
+  }
+}
+</script>
+
+<div id="{{ $uniqueId }}" class="iframe-fullscreen-wrapper">
+  <button onclick="toggleFullscreen('{{ $uniqueId }}')">⛶ Fullscreen</button>
+  <iframe src="{{ $src }}" title="{{ $title }}" allow="fullscreen"></iframe>
+</div>
+
+<div class="iframe-mobile-msg">
+  <h3>💻 Desktop Experience Recommended</h3>
+  <p>For the best experience working with integrations, we recommend using Kaoto on a desktop or laptop device.</p>
+  <p>Mobile screens are too small to effectively visualize and manage complex integration flows.</p>
+</div>

--- a/layouts/shortcodes/iframe-fullscreen.html
+++ b/layouts/shortcodes/iframe-fullscreen.html
@@ -88,7 +88,7 @@ function toggleFullscreen(wrapperId) {
 
 <div id="{{ $uniqueId }}" class="iframe-fullscreen-wrapper">
   <button onclick="toggleFullscreen('{{ $uniqueId }}')">⛶ Fullscreen</button>
-  <iframe src="{{ $src }}" title="{{ $title }}" allow="fullscreen"></iframe>
+  <iframe src="{{ $src }}" title="{{ $title }}" allow="fullscreen" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"></iframe>
 </div>
 
 <div class="iframe-mobile-msg">


### PR DESCRIPTION
Add a playground tab with kaoto online embedded into an iframe. For this, it was created a shortcode that includes a fullscreen button. This enables the playground until screenwidth > 700. Below that it shows a message directing the users to open kaoto in a desktop

<img width="1663" height="919" alt="image" src="https://github.com/user-attachments/assets/d535258f-c9dd-4b04-a3c3-7a17ed2af000" />

<img width="1091" height="877" alt="image" src="https://github.com/user-attachments/assets/3e78010a-d0eb-4859-b09f-9948f049935d" />

fix: https://github.com/KaotoIO/kaoto.io/issues/237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Playground" to the main navigation.
  * New Playground landing page embedding a fullscreen interactive experience.
  * Fullscreen-capable iframe embed with a toggle and mobile fallback message.

* **Style**
  * Responsive header/navbar alignment updated for very large screens.
  * Several content blocks adjusted to change maximum content widths for improved layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->