### PR TITLE
feat(figures): migrate to figure shortcode remaining tags

### DIFF
--- a/content/blog/kaoto-2.3-release/index.md
+++ b/content/blog/kaoto-2.3-release/index.md
@@ -14,7 +14,7 @@ tags:
 It has been over 2 months since the Kaoto 2.2 release and we are excited to provide you now with the new Kaoto 2.3 version.
 Please take a look below to learn about the exciting new things we added in this release.
 
-<p align="center"><img src="./CamelJedi.png" alt="Camel Jedi" style="height: 400px;"/></p>
+{{< figure src="./CamelJedi.png" alt="Camel Jedi" caption="Camel Jedi" class="image" >}}
 
 ## Features & Improvements
 
@@ -22,17 +22,17 @@ Please take a look below to learn about the exciting new things we added in this
 
 We have added more choices to the Camel version selector. Now you will be able to choose between the latest community release, the latest LTS community release as well as the Red Hat Build of Apache Camel releases.
 
-<p align="center"><img src="./camel-versions.gif" alt="showcasing the version selector" style="height: 400px;"/></p>
+{{< figure src="./camel-versions.gif" alt="Showcasing the version selector" caption="Showcasing the version selector" class="image" >}}
 
 #### Visual Data Mapping & Transformation Editor (Tech Preview available in VS Code)
 
 This feature has been requested a lot and we are very happy to provide you with the first iteration of a fully new Data Mapping UI which enables you to do your mappings and transformations in a drag and drop way. In comparison to AtlasMap the new Kaoto DataMapper works based on XSLT and does not require a specific custom runtime component to work. <br>
 
-<p align="center"><img src="./datamapper-icon.png" alt="showcasing the datamapper icon"/></p>
+{{< figure src="./datamapper-icon.png" alt="Showcasing the datamapper icon" caption="Showcasing the datamapper icon" class="image" >}}
 
 This first iteration marks only the beginning of the Kaoto DataMapper story. There are still many more features and capabilities we want to add over the coming months.
 
-<p align="center"><img src="./featured.png" alt="showcasing the datamapper" style="height: 600px;"/></p>
+{{< figure src="./featured.png" alt="Showcasing the datamapper" caption="Showcasing the datamapper" class="image" >}}
 
 Click the video below to watch a short Kaoto DataMapper introduction:
 [![Watch the Kaoto DataMapper introduction](https://img.youtube.com/vi/iz0yYThHZMc/hqdefault.jpg)](https://www.youtube.com/watch?v=iz0yYThHZMc)
@@ -41,7 +41,7 @@ Click the video below to watch a short Kaoto DataMapper introduction:
 
 Our long term goal is to improve the usability in a way that users can reach most of the functionalities of Kaoto with the least amount of clicks and searching. Efficiency is key to make using Kaoto a fun experience for everyone. A first step in that direction is the new toolbar. In the long run we hope to make this the replacement for the right-click context menu.
 
-<p align="center"><img src="./toolbar.png" alt="showcasing the toolbar" style="height: 200px;"/></p>
+{{< figure src="./toolbar.png" alt="Showcasing the toolbar" caption="Showcasing the toolbar" class="image" >}}
 
 In the default settings the toolbar will be visible when hovering over a step or group. However you can also change that behavior in the *Settings* dialog to be only visible when selecting a step or group.
 
@@ -49,29 +49,29 @@ In the default settings the toolbar will be visible when hovering over a step or
 
 Prototyping a new integration should be as easy and fast as possible in a visual designer. To get closer to that state we added a quick action at the end of each group in your integration which is visible as an **arrow** button. You can now easily append new steps to your integration by clicking that button.
 
-<p align="center"><img src="./append.png" alt="showcasing the append button" style="height: 200px;"/></p>
+{{< figure src="./append.png" alt="Showcasing the append button" caption="Showcasing the append button" class="image" >}}
 
 We also introduced an easier way to insert steps between existing ones. You can now just hover over the connection between two steps and this will reveal a **+** button you can use to insert a new step.
 
-<p align="center"><img src="./insert.png" alt="showcasing the insert button" style="height: 200px;"/></p>
+{{< figure src="./insert.png" alt="Showcasing the insert button" caption="Showcasing the insert button" class="image" >}}
 
 #### New Placeholders
 
 Whenever there is a container step without any step contained we will now show you a placeholder labeled "*Add step*" to signal where you can add new steps.
 
-<p align="center"><img src="./placeholders.png" alt="showcasing the placeholders" style="height: 300px;"/></p>
+{{< figure src="./placeholders.png" alt="Showcasing the placeholders" caption="Showcasing the placeholders" class="image" >}}
 
 #### New Action: Enable All
 
 During the creation of your integration you may have disabled one or more steps for various purposes. Going through your integration now and manually enabling all the deactived steps can be a tedious task and this situation led to the addition of the new "Enable All" action. You can now reactivate all the disabled steps with a single click.
 
-<p align="center"><img src="./enableall.png" alt="showcasing the enableAll button" style="height: 400px;"/></p>
+{{< figure src="./enableall.png" alt="Showcasing the enableAll button" caption="Showcasing the enableAll button" class="image" >}}
 
 #### New Action: Show All
 
 There is a new action available now which lets you quickly show or hide all of your routes.
 
-<p align="center"><img src="./showall.gif" alt="showcasing the Show All button" /></p>
+{{< figure src="./showall.gif" alt="Showcasing the Show All button" caption="Showcasing the Show All button" class="image" >}}
 
 #### Other Enhancements
 

--- a/content/blog/kaoto-2.5-release/index.md
+++ b/content/blog/kaoto-2.5-release/index.md
@@ -20,21 +20,21 @@ Please take a look below to learn about the exciting new things we added to this
 
 This version includes the latest Camel catalog version 4.11.0, which brings new components and features to enhance your integration capabilities, alongside the latest LTS version 4.10.3.
 
-<p align="center"><img src="./new-camel-versions.png" alt="showcasing the version selector" /></p>
+{{< figure src="./new-camel-versions.png" alt="showcasing the version selector" caption="Showcasing the version selector" class="image" >}}
 
 #### XML IO Support
 
 Not everyone likes YAML and we are happy to help here and announce that Kaoto now supports the Camel XML IO DSL.
 
-<p align="center"><img src="./xml-route.png" alt="showcasing an XML IO route"/></p>
+{{< figure src="./xml-route.png" alt="showcasing an XML IO route" caption="Showcasing an XML IO route" class="image" >}}
 
 #### Generate Markdown Documentation
 
 Do you want to document your routes effortlessly? You can now export your integration flows with Kaoto as Markdown documents, including a visual representation of the flow in addition to the changed route parameters, making it easier to share and review routes.
 
-<p align="center"><img src="./generate-route-documentation.png" alt="Generate Route documentation"/></p>
+{{< figure src="./generate-route-documentation.png" alt="Generate Route documentation" caption="Generate Route documentation" class="image" >}}
 
-<p align="center"><img src="./documentation-preview.png" alt="Documentation preview"/></p>
+{{< figure src="./documentation-preview.png" alt="Documentation preview" caption="Documentation preview" class="image" >}}
 
 #### DataMapper Enhancements
 
@@ -42,7 +42,7 @@ Do you want to document your routes effortlessly? You can now export your integr
 * UI polish for better drag-and-drop experience
 * Update generated XSLT version to 3.0
 
-<p align="center"><img src="./datamapper.png" alt="DataMapper News"/></p>
+{{< figure src="./datamapper.png" alt="DataMapper News" caption="DataMapper News" class="image" >}}
 
 #### New Kaoto Perspective in VS Code
 
@@ -55,31 +55,31 @@ The Kaoto VS Code extension has been reworked heavily and our goal was to provid
   * a `Deployments` section providing easy access to local running integrations and their statuses with easy to access actions (start, stop, pause, resume, log, ...)
   * a `Help & Feedback` section providing links to useful resources for your daily work
 
-<p align="center"><img src="./kaoto-perspective.png" alt="Shows the new Kaoto perspective in VS Code"/></p>
+{{< figure src="./kaoto-perspective.png" alt="Shows the new Kaoto perspective in VS Code" caption="Shows the new Kaoto perspective in VS Code" class="image" >}}
 
 #### Configuration Form Enhancements
 
 We’re introducing a new Kaoto Form, a redesigned form engine with improved field behavior, better keyboard navigation and filtering for dropdown fields, the possibility to wrap the values in a `RAW()` function call and a new `Clear` button to completely remove the field from the source code.
 
-<p align="center"><img src="./field-contextual-menu.png" alt="Field contextual menu"/></p>
+{{< figure src="./field-contextual-menu.png" alt="Field contextual menu" caption="Field contextual menu" class="image" >}}
 
 #### Filter Flows in the Flows List
 
 You can now filter the flows in the flows list by name, making it easier to find specific routes in larger projects.
 
-<p align="center"><img src="./filter-flows.png" alt="Filter flows"/></p>
+{{< figure src="./filter-flows.png" alt="Filter flows" caption="Filter flows" class="image" >}}
 
 #### Dark Mode
 
 For those who fancy a darker theme, Kaoto now supports dark mode in the VS Code extension. You can switch to dark mode in the settings.
 
-<p align="center"><img src="./kaoto-dark-mode.png" alt="Kaoto dark mode"/></p>
+{{< figure src="./kaoto-dark-mode.png" alt="Kaoto dark mode" caption="Kaoto dark mode" class="image" >}}
 
 #### DevSpaces Ready with Devfile Support
 
 Kaoto now includes an OpenShift-compatible devfile.yaml, making it easier to develop Kaoto in OpenShift Dev Spaces or similar cloud-based workspaces.
 
-<p align="center"><img src="./openshift-commands.png" alt="Devfile options"/></p>
+{{< figure src="./openshift-commands.png" alt="Devfile options" caption="Devfile options" class="image" >}}
 
 #### Other Enhancements
 

--- a/content/blog/kaoto-2.7-release/index.md
+++ b/content/blog/kaoto-2.7-release/index.md
@@ -19,7 +19,7 @@ Please take a look below to learn about the exciting new things we added to this
 
 ### Data Mapper JSON Support (Tech Preview)
 
-<p align="center"><img src="./datamapper-json.png" alt="DataMapper JSON Support" /></p>
+{{< figure src="./datamapper-json.png" alt="DataMapper JSON Support" caption="DataMapper JSON Support" class="image" >}}
 
 Building on the XML support introduced earlier, the Data Mapper now enables you to:
 
@@ -50,7 +50,7 @@ You can find more detailed information about the Data Mapper in our online [user
 
 If you are using the Kaoto VS Code extension and you work in a Maven project then this little improvement might delight you. Whenever you add a new component endpoint to your route, upon saving your `pom.xml` file gets updated with the required dependency.
 
-<p align="center"><img src="./dep-update.gif" alt="showcasing the dependency update" /></p>
+{{< figure src="./dep-update.gif" alt="showcasing the dependency update" caption="Showcasing the dependency update" class="image" >}}
 
 ### Drag & Drop Support
 
@@ -111,7 +111,7 @@ Your browser does not support the video tag.
 
 * Switch between `to`, `toD`, and `poll` variants directly in the form
 
-<p align="center"><img src="./endpoint-switch.png" alt="showcasing the endpoint type selector" /></p>
+{{< figure src="./endpoint-switch.png" alt="showcasing the endpoint type selector" caption="Showcasing the endpoint type selector" class="image" >}}
 
 * Preserve expressions when switching between different languages
 * Improved parameter handling with URI parsing enhancements


### PR DESCRIPTION
Migrated HTML image tags to Hugo `figure` shortcode in blog posts and capitalized captions.

### Changes
- **Migrated 27 images** from `<p align="center"><img>` to `{{< figure >}}` shortcode
  - `content/blog/kaoto-2.3-release/index.md` (10 images)
  - `content/blog/kaoto-2.5-release/index.md` (9 images)
  - `content/blog/kaoto-2.7-release/index.md` (3 images)
- **Capitalized captions** in kaoto-2.3-release to match style guidelines
- **Preserved inline icons** in documentation (5 images with special inline styling)

### Benefits
- Consistent with Hugo best practices and recent blog posts (kaoto-2.10-release)
- Improved maintainability using standard shortcode syntax
- Better semantic HTML with proper figure/figcaption elements

fix: https://github.com/KaotoIO/kaoto.io/issues/190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved release notes with enhanced image formatting, captions, and accessibility features across multiple release post pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KaotoIO/kaoto.io/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->