### PR TITLE
introduced aliases to the blog posts…

### DIFF
--- a/content/blog/2024/kaoto-2.0-release/index.md
+++ b/content/blog/2024/kaoto-2.0-release/index.md
@@ -8,6 +8,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.0
+aliases:
+  - /blog/kaoto-2.0-release/
 ---
 ## It's time to celebrate the 2.0.0 release of Kaoto
 

--- a/content/blog/2024/kaoto-2.0.TP1-release/index.md
+++ b/content/blog/2024/kaoto-2.0.TP1-release/index.md
@@ -9,6 +9,8 @@ tags:
   - Release
   - Kaoto 2.0 TP1
   - Tech Preview
+aliases:
+  - /blog/kaoto-2.0.tp1-release/
 ---
 # With this 2.0.0 TP1 (Tech Preview) release we open up a new chapter for the Kaoto project. We leveraged all the strengths of Kaoto v1 and used the time to use the upstream [Apache Camel](https://camel.apache.org/) models and schemas directly, which will ensure that we provide the latest features of [Apache Camel](https://camel.apache.org/) in Kaoto. In addition we managed to add new features and usability improvements while also trying to keep most of the functionality of Kaoto v1.
 

--- a/content/blog/2024/kaoto-2.0.TP2-release/index.md
+++ b/content/blog/2024/kaoto-2.0.TP2-release/index.md
@@ -9,6 +9,8 @@ tags:
   - Release
   - Kaoto 2.0 TP2
   - Tech Preview
+aliases:
+  - /blog/kaoto-2.0.tp2-release/
 ---
 **We are happy to announce the release of Kaoto 2.0.0 TP2 (Tech Preview 2).**
 

--- a/content/blog/2024/kaoto-2.0.TP3-release/index.md
+++ b/content/blog/2024/kaoto-2.0.TP3-release/index.md
@@ -9,6 +9,8 @@ tags:
   - Release
   - Kaoto 2.0 TP3
   - Tech Preview
+aliases:
+  - /blog/kaoto-2.0.tp3-release/
 ---
 **We are happy to announce the release of Kaoto 2.0.0 TP3 (Tech Preview 3).**
 

--- a/content/blog/2024/kaoto-2.1-release/index.md
+++ b/content/blog/2024/kaoto-2.1-release/index.md
@@ -8,6 +8,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.1
+aliases:
+  - /blog/kaoto-2.1-release/
 ---
 ## It's time to welcome the 2.1.0 release of Kaoto
 

--- a/content/blog/2024/kaoto-2.2-release/index.md
+++ b/content/blog/2024/kaoto-2.2-release/index.md
@@ -8,6 +8,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.2
+aliases:
+  - /blog/kaoto-2.2-release/
 ---
 ## Say "Hello" to Kaoto 2.2.0
 

--- a/content/blog/2024/kaoto-2.3-release/index.md
+++ b/content/blog/2024/kaoto-2.3-release/index.md
@@ -8,6 +8,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.3
+aliases:
+  - /blog/kaoto-2.3-release/
 ---
 ## What's new?
 

--- a/content/blog/2025/kaoto-2.4-release/index.md
+++ b/content/blog/2025/kaoto-2.4-release/index.md
@@ -8,6 +8,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.4
+aliases:
+  - /blog/kaoto-2.4-release/
 ---
 ## What's new?
 

--- a/content/blog/2025/kaoto-2.5-release/index.md
+++ b/content/blog/2025/kaoto-2.5-release/index.md
@@ -8,6 +8,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.5
+aliases:
+  - /blog/kaoto-2.5-release/
 ---
 ## What's new?
 

--- a/content/blog/2025/kaoto-2.6-release/index.md
+++ b/content/blog/2025/kaoto-2.6-release/index.md
@@ -8,6 +8,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.6
+aliases:
+  - /blog/kaoto-2.6-release/
 ---
 ## What's new?
 

--- a/content/blog/2025/kaoto-2.7-release/index.md
+++ b/content/blog/2025/kaoto-2.7-release/index.md
@@ -8,6 +8,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.7
+aliases:
+  - /blog/kaoto-2.7-release/
 ---
 ## What's new?
 

--- a/content/blog/2025/kaoto-2.8-release/index.md
+++ b/content/blog/2025/kaoto-2.8-release/index.md
@@ -8,6 +8,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.8
+aliases:
+  - /blog/kaoto-2.8-release/
 ---
 ## What's new?
 

--- a/content/blog/2025/kaoto-2.9-release/index.md
+++ b/content/blog/2025/kaoto-2.9-release/index.md
@@ -8,6 +8,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.9
+aliases:
+  - /blog/kaoto-2.9-release/
 ---
 ## What's New?
 

--- a/content/blog/2026/docs-revamp/index.md
+++ b/content/blog/2026/docs-revamp/index.md
@@ -9,6 +9,8 @@ tags:
   - Kaoto
   - Documentation
   - Guide
+aliases:
+  - /blog/docs-revamp/
 ---
 
 ## A Fresh Start for Kaoto Documentation

--- a/content/blog/2026/drag-and-drop/index.md
+++ b/content/blog/2026/drag-and-drop/index.md
@@ -11,6 +11,8 @@ tags:
   - Visual Designer
   - Apache Camel
   - UX
+aliases:
+  - /blog/drag-and-drop/
 ---
 
 ## Introduction

--- a/content/blog/2026/file-monitoring-workshop/index.md
+++ b/content/blog/2026/file-monitoring-workshop/index.md
@@ -10,6 +10,8 @@ tags:
   - Message Filter Pattern
   - Apache Camel
   - Beginner
+aliases:
+  - /blog/file-monitoring-workshop/
 ---
 
 We're excited to announce an updated **beginner-level workshop** that teaches you how to build a file monitoring integration using **Kaoto's visual designer** and **Apache Camel**!

--- a/content/blog/2026/kaoto-2.10-release/index.md
+++ b/content/blog/2026/kaoto-2.10-release/index.md
@@ -11,6 +11,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.10
+aliases:
+  - /blog/kaoto-2.10-release/
 ---
 
 ## What's New?

--- a/content/blog/2026/kaoto-2.11-release/index.md
+++ b/content/blog/2026/kaoto-2.11-release/index.md
@@ -12,6 +12,8 @@ tags:
   - Kaoto
   - Release
   - Kaoto 2.11
+aliases:
+  - /blog/kaoto-2.11-release/
 ---
 
 ## What's New?

--- a/content/blog/2026/process-csv/index.md
+++ b/content/blog/2026/process-csv/index.md
@@ -12,6 +12,8 @@ tags:
   - PostgreSQL
   - Data Pipeline
   - Intermediate
+aliases:
+  - /blog/process-csv/
 ---
 
 We're excited to announce a new **intermediate-level workshop** that teaches you how to build a complete data processing pipeline using **Kaoto's visual designer** and **Apache Camel**!


### PR DESCRIPTION
introduced aliases to the blog posts to prevent breakage after the introduction of year based structure in URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added alternate URL paths for blog posts, enabling more accessible links to release announcements and documentation articles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->