### PR TITLE
fix(docs): Provide redirect for Runtime docs

### DIFF
--- a/content/docs/designer/04-runtime-selector/_index.md
+++ b/content/docs/designer/04-runtime-selector/_index.md
@@ -3,6 +3,8 @@ title: "Runtime Selector"
 description: "update here"
 date: 2026-03-25
 weight: 4
+aliases:
+  - /docs/manual/09_generatingcatalog/
 ---
 
 ## Overview


### PR DESCRIPTION
### Context
After the documentation revamp, some links moved. The Runtime documentation was among those changes.

### Changes
This commit adds a redirection for this link in order to avoid 404 at the VS Code Kaoto settings side.

We go from `/docs/manual/09_generatingcatalog/` to `/docs/designer/04-runtime-selector/`

fix: https://github.com/KaotoIO/vscode-kaoto/issues/1435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a page alias so this documentation can also be reached from an additional URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->