### PR TITLE
fix(docs): Provide redirect for Runtime docs

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,5 +1,7 @@
 ---
 title: "Documentation"
+aliases:
+  - /docs/manual/
 ---
 
 Welcome to the **official Kaoto documentation**!


### PR DESCRIPTION
### Context
After the documentation revamp, some links moved. The documentation root was among those changes.

### Changes
This commit adds a redirection for this link in order to avoid 404 at the VS Code Kaoto README.md side.

We go from `/docs/manual/` to `/docs/`

fix: https://github.com/KaotoIO/vscode-kaoto/issues/1435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an additional documentation URL alias so the same page can be reached from `/docs/manual/` as well as the existing path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->